### PR TITLE
[mdns] _hostname_is_ours access possibly null variables

### DIFF
--- a/components/mdns/include/mdns.h
+++ b/components/mdns/include/mdns.h
@@ -113,6 +113,18 @@ esp_err_t mdns_init(void);
 void mdns_free(void);
 
 /**
+ * @brief  Check whether mDNS is running
+ *
+ */
+bool mdns_is_initialized();
+
+/**
+ * @brief  Check whether mDNS has a hostname set
+ *
+ */
+bool mdns_has_hostname();
+
+/**
  * @brief  Set the hostname for mDNS server
  *         required if you want to advertise services
  *

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -1321,18 +1321,20 @@ static void _mdns_remove_scheduled_answer(mdns_if_t tcpip_if, mdns_ip_protocol_t
     while (q) {
         if (q->tcpip_if == tcpip_if && q->ip_protocol == ip_protocol && q->distributed) {
             mdns_out_answer_t * a = q->answers;
-            if (a->type == type && a->service == service->service) {
-                q->answers = q->answers->next;
-                free(a);
-            } else {
-                while (a->next) {
-                    if (a->next->type == type && a->next->service == service->service) {
-                        mdns_out_answer_t * b = a->next;
-                        a->next = b->next;
-                        free(b);
-                        break;
+            if (a) {
+                if (a->type == type && a->service == service->service) {
+                    q->answers = q->answers->next;
+                    free(a);
+                } else {
+                    while (a->next) {
+                        if (a->next->type == type && a->next->service == service->service) {
+                            mdns_out_answer_t *b = a->next;
+                            a->next = b->next;
+                            free(b);
+                            break;
+                        }
+                        a = a->next;
                     }
-                    a = a->next;
                 }
             }
         }

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -2578,6 +2578,9 @@ static int _mdns_check_aaaa_collision(esp_ip6_addr_t * ip, mdns_if_t tcpip_if)
 
 static bool _hostname_is_ours(const char * hostname)
 {
+    if (_mdns_server == NULL || hostname == NULL || _mdns_server->hostname == NULL) {
+        return false;
+    }
     if (strcasecmp(hostname, _mdns_server->hostname) == 0) {
         return true;
     }

--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -24,7 +24,7 @@ static const char * MDNS_SUB_STR = "_sub";
 
 mdns_server_t * _mdns_server = NULL;
 static mdns_host_item_t * _mdns_host_list = NULL;
-static mdns_host_item_t _mdns_self_host;
+static mdns_host_item_t _mdns_self_host = {.hostname = NULL, .address_list = NULL, .next = NULL};
 
 static const char *TAG = "MDNS";
 
@@ -4924,6 +4924,14 @@ void mdns_free(void)
     vSemaphoreDelete(_mdns_server->lock);
     free(_mdns_server);
     _mdns_server = NULL;
+}
+
+bool mdns_is_initialized() {
+    return _mdns_server != NULL;
+}
+
+bool mdns_has_hostname() {
+    return mdns_is_initialized() && _mdns_server->hostname != NULL &&  _mdns_self_host.hostname != NULL;
 }
 
 esp_err_t mdns_hostname_set(const char * hostname)


### PR DESCRIPTION
The _hostname_is_ours function access the _mdns variable and it's hostname variable even though they may be null. This commit checks for null and returns false since the hostname clearly is not one of ours.