### PR TITLE
Fix linker error in bt component if bss to extram is used

### DIFF
--- a/components/bt/linker.lf
+++ b/components/bt/linker.lf
@@ -12,6 +12,12 @@ entries:
     bt_common -> dram0_bss
     data -> dram0_data
 
+[scheme:bt_extram_bss]
+entries:
+    bt_bss -> extern_ram
+    bt_common -> extern_ram
+    data -> dram0_data
+
 # For the following fragments, order matters for
 # 'ALIGN(4) ALIGN(4, post) SURROUND(sym)', which generates:
 #
@@ -24,12 +30,17 @@ entries:
 [mapping:bt]
 archive: libbt.a
 entries:
-    * (bt_start_end);
-        bt_bss -> dram0_bss ALIGN(4) ALIGN(4, post) SURROUND(bt_bss),
-        bt_common -> dram0_bss ALIGN(4) ALIGN(4, post) SURROUND(bt_common),
-        data -> dram0_data  ALIGN(4) ALIGN(4, post) SURROUND(bt_data)
     if ESP_ALLOW_BSS_SEG_EXTERNAL_MEMORY = y:
-        * (extram_bss)
+        * (bt_extram_bss);
+            bt_bss -> extern_ram ALIGN(4) ALIGN(4, post) SURROUND(bt_bss),
+            bt_common -> extern_ram ALIGN(4) ALIGN(4, post) SURROUND(bt_common),
+            data -> dram0_data  ALIGN(4) ALIGN(4, post) SURROUND(bt_data)
+    else:
+        * (bt_start_end);
+            bt_bss -> dram0_bss ALIGN(4) ALIGN(4, post) SURROUND(bt_bss),
+            bt_common -> dram0_bss ALIGN(4) ALIGN(4, post) SURROUND(bt_common),
+            data -> dram0_data  ALIGN(4) ALIGN(4, post) SURROUND(bt_data)
+
 
 [mapping:btdm]
 archive: libbtdm_app.a


### PR DESCRIPTION
Fix for https://github.com/espressif/esp-idf/issues/10427. So far we did not encounter any problems.

(cherry picked from commit f24ab66e67a006761d463db68015abdbac74316c)