### PR TITLE
prevent overflow in time conversion msec -> ticks

### DIFF
--- a/components/freertos/FreeRTOS-Kernel/include/freertos/projdefs.h
+++ b/components/freertos/FreeRTOS-Kernel/include/freertos/projdefs.h
@@ -45,7 +45,7 @@ typedef void (* TaskFunction_t)( void * );
  * overridden by a macro of the same name defined in FreeRTOSConfig.h in case the
  * definition here is not suitable for your application. */
 #ifndef pdMS_TO_TICKS
-    #define pdMS_TO_TICKS( xTimeInMs )    ( ( TickType_t ) ( ( ( TickType_t ) ( xTimeInMs ) * ( TickType_t ) configTICK_RATE_HZ ) / ( TickType_t ) 1000U ) )
+    #define pdMS_TO_TICKS( xTimeInMs )    ( ( TickType_t ) ( ( ( uint64_t ) ( xTimeInMs ) * ( uint64_t ) configTICK_RATE_HZ ) / ( uint64_t ) 1000 ) )
 #endif
 #ifndef pdTICKS_TO_MS
     #define pdTICKS_TO_MS( xTicks )       ( ( TickType_t ) ( ( uint64_t ) ( xTicks ) * 1000 / configTICK_RATE_HZ ) )


### PR DESCRIPTION
A 12h timer leads to an overflow in 32 bit gymnasics.  This is changed to 64bit.